### PR TITLE
Replace deprecated core23 library with nucelos library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": "^7.3",
         "ext-json": "*",
         "ext-soap": "*",
-        "core23/twig-extensions": "^1.4",
+        "nucleos/twig-extensions": "^2.0",
         "psr/log": "^1.0",
         "sonata-project/block-bundle": "^3.21 || ^4.2",
         "sonata-project/doctrine-extensions": "^1.1",

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
 
 namespace Nucleos\AllInklBundle\Tests\App;
 
-use Core23\Twig\Bridge\Symfony\Bundle\Core23TwigBundle;
 use Nucleos\AllInklBundle\NucleosAllInklBundle;
 use Nucleos\AllInklBundle\Tests\App\Controller\TestController;
+use Nucleos\Twig\Bridge\Symfony\Bundle\NucleosTwigBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Bundle\TwigBundle\TwigBundle;
@@ -42,7 +42,7 @@ final class AppKernel extends Kernel
     {
         yield new FrameworkBundle();
         yield new TwigBundle();
-        yield new Core23TwigBundle();
+        yield new NucleosTwigBundle();
         yield new NucleosAllInklBundle();
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

The `twig-extensions` library was moved to the `nucleos` organisation.
